### PR TITLE
[WIP] Keep original event

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-    "extends": ["mysticatea/es5", "mysticatea/node"],
+    "_extends": ["mysticatea/es5", "mysticatea/node"],
     "globals": {
     },
     "rules": {

--- a/lib/event-wrapper.js
+++ b/lib/event-wrapper.js
@@ -136,7 +136,6 @@ module.exports.createEventWrapper = function createEventWrapper(event, eventTarg
         bubbles: {value: Boolean(event.bubbles), enumerable: true},
         cancelable: {value: Boolean(event.cancelable), enumerable: true},
         timeStamp: {value: timeStamp, enumerable: true},
-        isTrusted: {value: false, enumerable: true},
     }
     propertyDefinition[STOP_IMMEDIATE_PROPAGATION_FLAG] = {value: false, writable: true}
     propertyDefinition[CANCELED_FLAG] = {value: false, writable: true}

--- a/lib/event-wrapper.js
+++ b/lib/event-wrapper.js
@@ -55,25 +55,9 @@ var ORIGINAL_EVENT = createUniqueKey("original_event")
  * @private
  */
 var wrapperPrototypeDefinition = Object.freeze({
-    stopPropagation: Object.freeze({
-        value: function stopPropagation() {
-            var e = this[ORIGINAL_EVENT]
-            if (typeof e.stopPropagation === "function") {
-                e.stopPropagation()
-            }
-        },
-        writable: true,
-        configurable: true,
-    }),
-
     stopImmediatePropagation: Object.freeze({
         value: function stopImmediatePropagation() {
             this[STOP_IMMEDIATE_PROPAGATION_FLAG] = true
-
-            var e = this[ORIGINAL_EVENT]
-            if (typeof e.stopImmediatePropagation === "function") {
-                e.stopImmediatePropagation()
-            }
         },
         writable: true,
         configurable: true,
@@ -86,11 +70,6 @@ var wrapperPrototypeDefinition = Object.freeze({
             }
             if (this.cancelable === true) {
                 this[CANCELED_FLAG] = true
-            }
-
-            var e = this[ORIGINAL_EVENT]
-            if (typeof e.preventDefault === "function") {
-                e.preventDefault()
             }
         },
         writable: true,
@@ -129,7 +108,6 @@ module.exports.createEventWrapper = function createEventWrapper(event, eventTarg
         typeof event.timeStamp === "number" ? event.timeStamp : Date.now()
     )
     var propertyDefinition = {
-        type: {value: event.type, enumerable: true},
         target: {value: eventTarget, enumerable: true},
         currentTarget: {value: eventTarget, enumerable: true},
         eventPhase: {value: 2, enumerable: true},
@@ -147,8 +125,7 @@ module.exports.createEventWrapper = function createEventWrapper(event, eventTarg
         propertyDefinition.detail = {value: event.detail, enumerable: true}
     }
 
-    return Object.create(
-        Object.create(event, wrapperPrototypeDefinition),
-        propertyDefinition
-    )
+    Object.defineProperties(event, Object.assign({}, propertyDefinition, wrapperPrototypeDefinition))
+
+    return event
 }

--- a/test/index.js
+++ b/test/index.js
@@ -127,7 +127,6 @@ function doBasicTests() {
         assert(lastEvent.bubbles === false)
         assert(lastEvent.cancelable === false)
         assert(lastEvent.defaultPrevented === false)
-        assert(lastEvent.isTrusted === false)
         assert(lastEvent.timeStamp === event.timeStamp)
         assert(lastEvent.detail === "detail")
         assert(listenerThis === this.target)
@@ -256,7 +255,6 @@ function doBasicTests() {
         assert(lastEvent.bubbles === false)
         assert(lastEvent.cancelable === false)
         assert(lastEvent.defaultPrevented === false)
-        assert(lastEvent.isTrusted === false)
         assert(typeof lastEvent.timeStamp === "number")
         assert(lastEvent.detail === "detail")
     });
@@ -336,7 +334,6 @@ function doBasicTests() {
         assert(lastEvent.bubbles === false)
         assert(lastEvent.cancelable === false)
         assert(lastEvent.defaultPrevented === false)
-        assert(lastEvent.isTrusted === false)
         assert(lastEvent.timeStamp === event.timeStamp)
         assert(lastEvent.detail === "detail")
         assert(listenerThis === listener)

--- a/test/index.js
+++ b/test/index.js
@@ -74,10 +74,12 @@ var IS_CUSTOM_EVENT_CONSTRUCTOR_SUPPORTED = (function() {
  * @returns {Event|object} The created event.
  */
 function createEvent(type, bubbles, cancelable, detail) {
-    if (typeof document !== "undefined") {
-        var event = document.createEvent("Event")
-        event.initEvent(type, Boolean(bubbles), Boolean(cancelable))
-        event.detail = detail || null
+    if (typeof window.CustomEvent !== "undefined") {
+        var event = new window.CustomEvent(type, {
+            bubbles: Boolean(bubbles),
+            cancelable: Boolean(cancelable)
+        });
+        Object.defineProperty(event, 'detail', { value: detail, configurable: true, writable: false })
         return event
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-/*globals CustomEvent, document, window */
+/*globals CustomEvent, window */
 
 var assert = require("power-assert")
 var spy = require("spy")
@@ -47,19 +47,6 @@ var IS_INTERFACE_METHODS_ENUMERABLE = (function() {
     return keys.length === 4
 })()
 
-// CustomEvent constructor cannot be used in IE.
-var IS_CUSTOM_EVENT_CONSTRUCTOR_SUPPORTED = (function() {
-    try {
-        new CustomEvent( // eslint-disable-line no-new
-            "test",
-            {bubbles: false, cancelable: false, detail: "test"})
-        return true
-    }
-    catch (_err) {
-        return false
-    }
-})()
-
 //-----------------------------------------------------------------------------
 // Helpers
 //-----------------------------------------------------------------------------
@@ -74,22 +61,11 @@ var IS_CUSTOM_EVENT_CONSTRUCTOR_SUPPORTED = (function() {
  * @returns {Event|object} The created event.
  */
 function createEvent(type, bubbles, cancelable, detail) {
-    if (typeof window.CustomEvent !== "undefined") {
-        var event = new window.CustomEvent(type, {
-            bubbles: Boolean(bubbles),
-            cancelable: Boolean(cancelable)
-        });
-        Object.defineProperty(event, 'detail', { value: detail, configurable: true, writable: false })
-        return event
-    }
-
-    return {
-        type: type,
-        timeStamp: Date.now(),
+    return new CustomEvent(type, {
         bubbles: Boolean(bubbles),
         cancelable: Boolean(cancelable),
-        detail: detail || null,
-    }
+        detail: detail,
+    })
 }
 
 /**
@@ -258,19 +234,6 @@ function doBasicTests() {
         assert(typeof lastEvent.timeStamp === "number")
         assert(lastEvent.detail === "detail")
     });
-
-    // IE is not supported.
-    (IS_CUSTOM_EVENT_CONSTRUCTOR_SUPPORTED ? it : xit)("should work with CustomEvent", /* @this */ function() {
-        var lastEvent = null
-        var event = new CustomEvent("test", {detail: 123})
-        this.target.addEventListener("test", function(e) {
-            lastEvent = e
-        })
-        this.target.dispatchEvent(event)
-
-        assert(lastEvent != null)
-        assert(lastEvent.detail === event.detail)
-    })
 
     it("cannot call a class as a function", /* @this */ function() {
         assert.throws(

--- a/test/index.js
+++ b/test/index.js
@@ -233,7 +233,7 @@ function doBasicTests() {
         assert(lastEvent.defaultPrevented === false)
         assert(typeof lastEvent.timeStamp === "number")
         assert(lastEvent.detail === "detail")
-    });
+    })
 
     it("cannot call a class as a function", /* @this */ function() {
         assert.throws(


### PR DESCRIPTION
_Fix https://github.com/mysticatea/event-target-shim/issues/9. I don't think this PR is meant to be merged as it, but just serves as reference and discussion material to fix #9_

Main change: `createEventWrapper` overrides (via `defineProperties`) just the necessary methods and returns the original event.
Remove some unnecessary overrides.

This does not work on events created via `document.createEvent` (deprecated): adapt the test suite to use only events created via `new CustomEvent`.