### PR TITLE
fix(package): code->node

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dist"
   ],
   "engines": {
-    "code": ">=4"
+    "node": ">=4"
   },
   "scripts": {
     "preversion": "npm test",


### PR DESCRIPTION
Typo was generating warning: 
> warning event-target-shim@3.0.1: The engine "code" appears to be invalid.