### PR TITLE
Fix: wrap listener.call with a try-catch block

### DIFF
--- a/src/event-target.mjs
+++ b/src/event-target.mjs
@@ -316,7 +316,14 @@ EventTarget.prototype = {
             // Call this listener
             setPassiveListener(wrappedEvent, (node.passive ? node.listener : null))
             if (typeof node.listener === "function") {
-                node.listener.call(this, wrappedEvent)
+                try {
+                    node.listener.call(this, wrappedEvent)
+                }
+                catch(err) {
+                    if (typeof console === "object" && typeof console.error === "function") {
+                        console.error(err)
+                    }
+                }
             }
             else if (node.listenerType !== ATTRIBUTE && typeof node.listener.handleEvent === "function") {
                 node.listener.handleEvent(wrappedEvent)


### PR DESCRIPTION
Consider

```javascript
const et = new EventTarget()
et.addEventListener('a', () => { console.log(1); throw whatever });
et.addEventListener('a', () => { console.log(2) });
et.dispatchEvent(new Event('a'));
```

We should be able to see `2` in the console.