### PR TITLE
Actually enable typescript tests

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -163,7 +163,7 @@ export interface EventTarget {
 }
 
 type EventAttributes<T extends string> = {
-    [K in T]: (ev: Event) => any;
+    [K in T]: ((ev: Event) => any) | null;
 };
 
 type EventTargetConstructor = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -122,7 +122,7 @@ export interface AddEventListenerOptions extends EventListenerOptions {
     once?: boolean;
 }
 
-export type EventTargetListener = ((event: Event) => any) | { handleEvent(event: Event): void };
+export type EventTargetListener = ((event: Event) => void) | { handleEvent(event: Event): void };
 
 export interface PartialEvent extends Partial<Event> {
     type: string;
@@ -163,7 +163,7 @@ export interface EventTarget {
 }
 
 type EventAttributes<T extends string> = {
-    [K in T]: ((ev: Event) => any) | null;
+    [K in T]: ((ev: Event) => void) | null;
 };
 
 type EventTargetConstructor = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,5 +4,10 @@
         "noEmit": true,
         "strict": true
     },
-    "exclude": ["test/types.ts"]
-}
+    "files": [
+        "test/types.ts"
+    ],
+    "exclude": [
+        "node_modules"
+    ]
+} 


### PR DESCRIPTION
...and discover that one type needs a minor addition.

Just to make sure that this is the last PR, I wanna ask you if you want to allow users to add `(ev: Event) => any`  or `(ev: Event) => void` callbacks? `addEventCallback` and its counterpart requires `(ev: Event) => void`, but I've added `(ev: Event) => any` by mistake. It doesn't break anything, just allows users to add callback with any kind of return type (it's not used anyway). However, it goes against the typescript's spec. Should I change it to `(ev: Event) => void` ?

My personal opinion - I should, but it's up to you since it doesn't break anything.

**Edit:**
It literally breaks nothing, just prevents user from using reusing callbacks incorrectly without manual type cast, if they decide they might want to retrieve callback from `EventTarget`'s attribute (for ex. `onabort`) for some reason. Thus I'm changing to `(ev: Event) => void`.