### PR TITLE
change console.assert to throw new TypeError

### DIFF
--- a/dist/event-target-shim.js
+++ b/dist/event-target-shim.js
@@ -43,11 +43,9 @@ const wrappers = new WeakMap();
  */
 function pd(event) {
     const retv = privateData.get(event);
-    console.assert(
-        retv != null,
-        "'this' is expected an Event object, but got",
-        event
-    );
+    if(retv === null){
+        throw new TypeError("'this' is expected an Event object, but got " + JSON.stringify(event));
+    }
     return retv
 }
 


### PR DESCRIPTION
on react-native 0.61, use console.assert may get
"console.assert is not a function" error

https://github.com/facebook/react-native/issues/26962

such as:

![image](https://user-images.githubusercontent.com/17643700/69225073-a21e3c80-0bb8-11ea-93cc-abc6a3bc6a55.png)
