### PR TITLE
Change signal option support info

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This implementation is designed ...
 | `EventTarget` constructor | ❌  | 87   | 84      | 87     | 14     | 15.4.0  |
 | `passive` option          | ❌  | 16   | 49      | 51     | 10     | 15.4.0  |
 | `once` option             | ❌  | 16   | 50      | 55     | 10     | 15.4.0  |
-| `signal` option           | ❌  | ❌   | ❌      | ❌     | ❌     | ❌      |
+| `signal` option           | ❌  | 88   | 86      | 88     | ❌     | ❌      |
 
 ---
 


### PR DESCRIPTION
Hello!

Chrome released `signal` in v88: https://www.chromestatus.com/feature/5658622220566528
Firefox released it in v86: https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/86#apis