### PR TITLE
event-target: make AddOptions type compatible with recent TS

### DIFF
--- a/src/lib/event-target.ts
+++ b/src/lib/event-target.ts
@@ -324,7 +324,7 @@ export namespace EventTarget {
     export interface AddOptions extends Options {
         passive?: boolean
         once?: boolean
-        signal?: AbortSignal | null | undefined
+        signal?: AbortSignal
     }
 
     /**

--- a/test/event-target.ts
+++ b/test/event-target.ts
@@ -179,7 +179,7 @@ describe("'EventTarget' class", () => {
 
         it("should not add the same listener twice even if signal flag is different.", () => {
             const f = () => {}
-            target.addEventListener("foo", f, { signal: null })
+            target.addEventListener("foo", f, {})
             target.addEventListener("foo", f, { signal: new AbortSignalStub() })
 
             assert.strictEqual(countEventListeners(target), 1)
@@ -192,7 +192,6 @@ describe("'EventTarget' class", () => {
             target.addEventListener("foo", f, {
                 passive: true,
                 once: true,
-                signal: null,
             })
             target.addEventListener("foo", f, {
                 passive: false,


### PR DESCRIPTION
Recent update in TS add `signal` property to `AddOptions` interface [1].
Over there, the definition is:

```ts
    signal?: AbortSignal;
```

You'll notice that `null` is not in the definition. This causes the
whole EventTarget type to be incompatible with TS one.

To fix this incompatibility, just remove `null` from the field's union.

[1] https://github.com/microsoft/TypeScript/blob/feac9eb126e56837d16acb61cd019ce8520db76c/src/lib/dom.generated.d.ts#L8